### PR TITLE
Fix GetUplinkRepresentor - Detecting incorrect Uplink Representor

### DIFF
--- a/sriovnet_switchdev_test.go
+++ b/sriovnet_switchdev_test.go
@@ -11,49 +11,112 @@ import (
 	utilfs "github.com/Mellanox/sriovnet/pkg/utils/filesystem"
 )
 
+type repContext struct {
+	Name         string // create files /sys/bus/pci/devices/<vf addr>/physfn/net/<Name> , /sys/class/net/<Name>
+	PhysPortName string // conditionally create if string is empty under /sys/class/net/<Name>/phys_port_name
+	PhysSwitchID string // conditionally create if string is empty under /sys/class/net/<Name>/phys_switch_id
+}
+
+func setUpRepresentorLayout(vfPciAddress string, rep *repContext) error {
+	path := filepath.Join(PciSysDir, vfPciAddress, "physfn/net", rep.Name)
+	err := utilfs.Fs.MkdirAll(path, os.FileMode(0755))
+	if err != nil {
+		return err
+	}
+
+	path = filepath.Join(NetSysDir, rep.Name)
+	err = utilfs.Fs.MkdirAll(path, os.FileMode(0755))
+	if err != nil {
+		return err
+	}
+
+	if rep.PhysPortName != "" {
+		physPortNamePath := filepath.Join(NetSysDir, rep.Name, netdevPhysPortName)
+		physPortNameFile, _ := utilfs.Fs.Create(physPortNamePath)
+		_, err = physPortNameFile.Write([]byte(rep.PhysPortName))
+		if err != nil {
+			return err
+		}
+	}
+
+	if rep.PhysSwitchID != "" {
+		physSwitchIDPath := filepath.Join(NetSysDir, rep.Name, netdevPhysSwitchID)
+		physSwitchIDFile, _ := utilfs.Fs.Create(physSwitchIDPath)
+		_, err = physSwitchIDFile.Write([]byte(rep.PhysSwitchID))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 //nolint:unparam
-func setupUplinkRepresentorEnv(t *testing.T, vfPciAddress string) func() {
+func setupUplinkRepresentorEnv(t *testing.T, uplink *repContext, vfPciAddress string, vfReps []*repContext) func() {
 	var err error
 	utilfs.Fs = utilfs.NewFakeFs()
-	path := filepath.Join(PciSysDir, vfPciAddress, "physfn/net", "eth0")
-	err = utilfs.Fs.MkdirAll(path, os.FileMode(0755))
 	defer func() {
 		if err != nil {
 			t.Errorf("setupUplinkRepresentorEnv, got %v", err)
 		}
 	}()
-	path = filepath.Join(NetSysDir, "eth0")
-	err = utilfs.Fs.MkdirAll(path, os.FileMode(0755))
-	path = filepath.Join(NetSysDir, "eth1")
-	err = utilfs.Fs.MkdirAll(path, os.FileMode(0755))
-	swIDFile := filepath.Join(NetSysDir, "eth0", netdevPhysSwitchID)
-	swID, err := utilfs.Fs.Create(swIDFile)
-	_, err = swID.Write([]byte("111111"))
+
+	err = setUpRepresentorLayout(vfPciAddress, uplink)
+	for _, rep := range vfReps {
+		err = setUpRepresentorLayout(vfPciAddress, rep)
+	}
+
 	return func() { utilfs.Fs.RemoveAll("/") } //nolint:errcheck
 }
 
-func TestGetUplinkRepresentorSuccess(t *testing.T) {
+func TestGetUplinkRepresentorWithPhysPortNameSuccess(t *testing.T) {
 	vfPciAddress := "0000:03:00.4"
-	teardown := setupUplinkRepresentorEnv(t, vfPciAddress)
+	uplinkRep := &repContext{"eth0", "p0", "111111"}
+	vfsReps := []*repContext{{"enp_0", "pf0vf0", "0123"},
+		{"enp_1", "pf0vf1", "0124"}}
+
+	teardown := setupUplinkRepresentorEnv(t, uplinkRep, vfPciAddress, vfsReps)
 	defer teardown()
 	uplinkNetdev, err := GetUplinkRepresentor(vfPciAddress)
 	assert.NoError(t, err)
 	assert.Equal(t, "eth0", uplinkNetdev)
 }
 
-func TestGetUplinkRepresentorErrorMissingSwID(t *testing.T) {
-	var testErr error
+func TestGetUplinkRepresentorWithoutPhysPortNameSuccess(t *testing.T) {
 	vfPciAddress := "0000:03:00.4"
-	expectedError := fmt.Sprintf("uplink for %s not found", vfPciAddress)
-	teardown := setupUplinkRepresentorEnv(t, vfPciAddress)
+	uplinkRep := &repContext{Name: "eth0", PhysSwitchID: "111111"}
+	var vfsReps []*repContext
+
+	teardown := setupUplinkRepresentorEnv(t, uplinkRep, vfPciAddress, vfsReps)
 	defer teardown()
-	swIDFile := filepath.Join(NetSysDir, "eth0", netdevPhysSwitchID)
-	testErr = utilfs.Fs.Remove(swIDFile)
-	defer func() {
-		if testErr != nil {
-			t.Errorf("setupUplinkRepresentorEnv, got %v", testErr)
-		}
-	}()
+	uplinkNetdev, err := GetUplinkRepresentor(vfPciAddress)
+	assert.NoError(t, err)
+	assert.Equal(t, "eth0", uplinkNetdev)
+}
+
+func TestGetUplinkRepresentorWithPhysPortNameFailed(t *testing.T) {
+	vfPciAddress := "0000:03:00.4"
+	uplinkRep := &repContext{"eth0", "invalid", "111111"}
+	vfsReps := []*repContext{{"enp_0", "pf0vf0", "0123"},
+		{"enp_1", "pf0vf1", "0124"}}
+
+	expectedError := fmt.Sprintf("uplink for %s not found", vfPciAddress)
+	teardown := setupUplinkRepresentorEnv(t, uplinkRep, vfPciAddress, vfsReps)
+	defer teardown()
+	uplinkNetdev, err := GetUplinkRepresentor(vfPciAddress)
+	assert.Error(t, err)
+	assert.Equal(t, "", uplinkNetdev)
+	assert.Equal(t, expectedError, err.Error())
+}
+
+func TestGetUplinkRepresentorErrorMissingSwID(t *testing.T) {
+	vfPciAddress := "0000:03:00.4"
+	uplinkRep := &repContext{Name: "eth0", PhysPortName: "p0"}
+	vfsReps := []*repContext{{Name: "enp_0", PhysPortName: "pf0vf0"},
+		{Name: "enp_1", PhysPortName: "pf0vf1"}}
+	expectedError := fmt.Sprintf("uplink for %s not found", vfPciAddress)
+	teardown := setupUplinkRepresentorEnv(t, uplinkRep, vfPciAddress, vfsReps)
+	defer teardown()
 	uplinkNetdev, err := GetUplinkRepresentor(vfPciAddress)
 	assert.Error(t, err)
 	assert.Equal(t, "", uplinkNetdev)
@@ -63,8 +126,10 @@ func TestGetUplinkRepresentorErrorMissingSwID(t *testing.T) {
 func TestGetUplinkRepresentorErrorEmptySwID(t *testing.T) {
 	var testErr error
 	vfPciAddress := "0000:03:00.4"
+	uplinkRep := &repContext{"eth0", "", ""}
+	var vfsReps []*repContext
 	expectedError := fmt.Sprintf("uplink for %s not found", vfPciAddress)
-	teardown := setupUplinkRepresentorEnv(t, vfPciAddress)
+	teardown := setupUplinkRepresentorEnv(t, uplinkRep, vfPciAddress, vfsReps)
 	defer teardown()
 	swIDFile := filepath.Join(NetSysDir, "eth0", netdevPhysSwitchID)
 	swID, testErr := utilfs.Fs.Create(swIDFile)
@@ -81,18 +146,8 @@ func TestGetUplinkRepresentorErrorEmptySwID(t *testing.T) {
 }
 
 func TestGetUplinkRepresentorErrorMissingUplink(t *testing.T) {
-	var testErr error
 	vfPciAddress := "0000:03:00.4"
-	teardown := setupUplinkRepresentorEnv(t, vfPciAddress)
 	expectedError := fmt.Sprintf("failed to lookup %s", vfPciAddress)
-	defer teardown()
-	path := filepath.Join(PciSysDir, vfPciAddress)
-	testErr = utilfs.Fs.RemoveAll(path)
-	defer func() {
-		if testErr != nil {
-			t.Errorf("setupUplinkRepresentorEnv, got %v", testErr)
-		}
-	}()
 	uplinkNetdev, err := GetUplinkRepresentor(vfPciAddress)
 	assert.Error(t, err)
 	assert.Equal(t, "", uplinkNetdev)


### PR DESCRIPTION
GetUplinkRepresentor return wrong uplink representor name when it's not preceding the Vfs representors alphabetical.

Fixes #32 