### PR TITLE
Rename GetRepresentorMacAddress

### DIFF
--- a/sriovnet_integration_test.go
+++ b/sriovnet_integration_test.go
@@ -262,7 +262,7 @@ func TestIntegrationGetRepresentorPortFlavour(t *testing.T) {
 	}
 }
 
-func TestIntegrationGetRepresentorMacAddress(t *testing.T) {
+func TestIntegrationGetRepresentorPeerMacAddress(t *testing.T) {
 	tcases := []struct {
 		netdev      string
 		expectedMac string
@@ -275,7 +275,7 @@ func TestIntegrationGetRepresentorMacAddress(t *testing.T) {
 	}
 
 	for _, tcase := range tcases {
-		mac, err := GetRepresentorMacAddress(tcase.netdev)
+		mac, err := GetRepresentorPeerMacAddress(tcase.netdev)
 		if tcase.shouldFail {
 			if err == nil {
 				t.Fatal("Expected failure but no error occured")
@@ -283,12 +283,12 @@ func TestIntegrationGetRepresentorMacAddress(t *testing.T) {
 			continue
 		}
 		if err != nil {
-			t.Fatal("GetRepresentorMacAddress failed with error: ", err)
+			t.Fatal("GetRepresentorPeerMacAddress failed with error: ", err)
 		}
 		if mac.String() != tcase.expectedMac {
 			t.Fatal("Actual MAC does not match expected MAC", mac, "!=", tcase.expectedMac)
 		}
-		t.Log("GetRepresentorMacAddress", "netdev: ", tcase.netdev, "Mac: ", mac)
+		t.Log("GetRepresentorPeerMacAddress", "netdev: ", tcase.netdev, "Mac: ", mac)
 	}
 }
 

--- a/sriovnet_switchdev.go
+++ b/sriovnet_switchdev.go
@@ -257,11 +257,12 @@ func parseSmartNICConfigFileOutput(out string) map[string]string {
 	return configMap
 }
 
-// GetRepresentorMacAddress returns the MAC address of the port identified by the given representor netdev
+// GetRepresentorPeerMacAddress returns the MAC address of the peer netdev associated with the given
+// representor netdev
 // Note:
 //    This method functionality is currently supported only for Smart-NICs.
 //    Currently only netdev representors with PORT_FLAVOUR_PCI_PF are supported
-func GetRepresentorMacAddress(netdev string) (net.HardwareAddr, error) {
+func GetRepresentorPeerMacAddress(netdev string) (net.HardwareAddr, error) {
 	flavor, err := GetRepresentorPortFlavour(netdev)
 	if err != nil {
 		return nil, fmt.Errorf("unknown port flavour for netdev %s. %v", netdev, err)

--- a/sriovnet_switchdev_test.go
+++ b/sriovnet_switchdev_test.go
@@ -308,7 +308,7 @@ func TestGetVfRepresentorPortFlavour(t *testing.T) {
 	}
 }
 
-func TestGetRepresentorMacAddress(t *testing.T) {
+func TestGetRepresentorPeerMacAddress(t *testing.T) {
 	// Create uplink and PF representor relate files
 	vfReps := []*repContext{
 		{
@@ -350,7 +350,7 @@ State      : Follow
 	}
 
 	for _, tcase := range tcases {
-		mac, err := GetRepresentorMacAddress(tcase.netdev)
+		mac, err := GetRepresentorPeerMacAddress(tcase.netdev)
 		if tcase.shouldFail {
 			assert.Error(t, err)
 		} else {


### PR DESCRIPTION
Rename GetRepresentorMacAddress() to
GetRepresentorPeerMacAddress() to better clarify
the MAC address returned is for the peer netdev
associated with the representor netdev and not
the mac address of the representor netdev itself.

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>