### PR TITLE
Change default controller ID to 1

### DIFF
--- a/sriovnet_switchdev.go
+++ b/sriovnet_switchdev.go
@@ -202,11 +202,11 @@ func GetVfRepresentorSmartNIC(pfID, vfIndex string) (string, error) {
 	// Note: no supoport for Multi-Chassis Smart-NICs
 	expectedPhysPortNames := map[string]interface{}{
 		fmt.Sprintf("pf%svf%s", pfID, vfIndex):   nil,
-		fmt.Sprintf("c0pf%svf%s", pfID, vfIndex): nil,
+		fmt.Sprintf("c1pf%svf%s", pfID, vfIndex): nil,
 	}
 
 	netdev, err := findNetdevWithPortNameCriteria(func(portName string) bool {
-		// if phys port name == pf<pfIndex>vf<vfIndex> or c0pf<pfIndex>vf<vfIndex> we have a match
+		// if phys port name == pf<pfIndex>vf<vfIndex> or c1pf<pfIndex>vf<vfIndex> we have a match
 		if _, ok := expectedPhysPortNames[portName]; ok {
 			return true
 		}


### PR DESCRIPTION
Kernel 5.10 or newer added support for encoding controler ID in the
physical port name of the representor  in cases where external
controller exists (Smart-NICs).

This controller ID is by default 1 and not 0.

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>