### PR TITLE
Refactoring - Change Smart-NIC to DPU

### DIFF
--- a/sriovnet_integration_test.go
+++ b/sriovnet_integration_test.go
@@ -229,10 +229,10 @@ func TestIntegrationGetPfPciFromVfPci(t *testing.T) {
 func TestIntegrationGetVfRepresentorSmartNIC(t *testing.T) {
 	pfID := "0"
 	vfIdx := "2"
-	t.Log("GetVfRepresentorSmartNIC ", "PF ID: ", pfID, "VF Index: ", vfIdx)
-	rep, err := GetVfRepresentorSmartNIC(pfID, vfIdx)
+	t.Log("GetVfRepresentorDPU ", "PF ID: ", pfID, "VF Index: ", vfIdx)
+	rep, err := GetVfRepresentorDPU(pfID, vfIdx)
 	if err != nil {
-		t.Log("GetVfRepresentorSmartNIC ", "Error: ", err)
+		t.Log("GetVfRepresentorDPU ", "Error: ", err)
 		t.Fatal()
 	}
 	t.Log("VF Representor: ", rep)

--- a/sriovnet_switchdev_test.go
+++ b/sriovnet_switchdev_test.go
@@ -105,8 +105,8 @@ func setupRepresentorEnv(t *testing.T, vfPciAddress string, vfReps []*repContext
 	return teardown
 }
 
-// setupSmartNICConfigFileForPort sets the config file content for a specific smart-NIC port of a given uplink
-func setupSmartNICConfigFileForPort(t *testing.T, uplink, portName, fileContent string) {
+// setupDPUConfigFileForPort sets the config file content for a specific DPU port of a given uplink
+func setupDPUConfigFileForPort(t *testing.T, uplink, portName, fileContent string) {
 	// This method assumes FakeFs it already set up
 	assert.IsType(t, &utilfs.FakeFs{}, utilfs.Fs)
 
@@ -205,7 +205,7 @@ func TestGetUplinkRepresentorErrorMissingUplink(t *testing.T) {
 	assert.Contains(t, err.Error(), expectedError)
 }
 
-func TestGetVfRepresentorSmartNIC(t *testing.T) {
+func TestGetVfRepresentorDPU(t *testing.T) {
 	vfReps := []*repContext{
 		{
 			Name:         "eth0",
@@ -226,12 +226,12 @@ func TestGetVfRepresentorSmartNIC(t *testing.T) {
 	teardown := setupRepresentorEnv(t, "", vfReps)
 	defer teardown()
 
-	vfRep, err := GetVfRepresentorSmartNIC("0", "2")
+	vfRep, err := GetVfRepresentorDPU("0", "2")
 	assert.NoError(t, err)
 	assert.Equal(t, "eth2", vfRep)
 }
 
-func TestGetVfRepresentorSmartNICNoRep(t *testing.T) {
+func TestGetVfRepresentorDPUNoRep(t *testing.T) {
 	vfReps := []*repContext{
 		{
 			Name:         "eth0",
@@ -247,19 +247,19 @@ func TestGetVfRepresentorSmartNICNoRep(t *testing.T) {
 	teardown := setupRepresentorEnv(t, "", vfReps)
 	defer teardown()
 
-	vfRep, err := GetVfRepresentorSmartNIC("1", "2")
+	vfRep, err := GetVfRepresentorDPU("1", "2")
 	assert.Error(t, err)
 	assert.Equal(t, "", vfRep)
 }
 
-func TestGetVfRepresentorSmartNICInvalidPfID(t *testing.T) {
-	vfRep, err := GetVfRepresentorSmartNIC("invalid", "2")
+func TestGetVfRepresentorDPUInvalidPfID(t *testing.T) {
+	vfRep, err := GetVfRepresentorDPU("invalid", "2")
 	assert.Error(t, err)
 	assert.Equal(t, "", vfRep)
 }
 
-func TestGetVfRepresentorSmartNICInvalidVfIndex(t *testing.T) {
-	vfRep, err := GetVfRepresentorSmartNIC("1", "invalid")
+func TestGetVfRepresentorDPUInvalidVfIndex(t *testing.T) {
+	vfRep, err := GetVfRepresentorDPU("1", "invalid")
 	assert.Error(t, err)
 	assert.Equal(t, "", vfRep)
 }
@@ -375,7 +375,7 @@ MAC        : 0c:42:a1:de:cf:7c
 MaxTxRate  : 0
 State      : Follow
 `
-	setupSmartNICConfigFileForPort(t, "eth0", "pf", repConfigFile)
+	setupDPUConfigFileForPort(t, "eth0", "pf", repConfigFile)
 	// Run test
 	tcases := []struct {
 		netdev      string


### PR DESCRIPTION
Data Processing Units are a new breed of Smart-NICs
A key difference is having a mulitcore processor able
to run commodity software as part of the SOC.

Some operations performed on DPUs are not supported
by standard Smart-NICs, properly rename relevant
methods to reflect that.

Note: As there has not been a release with the old
names, it is OK at this point to change naming of
user facing methods.

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>