### PR TITLE
Extend GetUplinkRepresentor to work with PF argument

### DIFF
--- a/sriovnet_integration_test.go
+++ b/sriovnet_integration_test.go
@@ -324,3 +324,29 @@ func TestIntegrationGetVfRepresentor(t *testing.T) {
 		t.Log("GetVfRepresentor", "uplink: ", tcase.uplink, " VF Index: ", tcase.vfIndex, " Rep: ", rep)
 	}
 }
+
+func TestIntegrationGetUplinkRepresentor(t *testing.T) {
+	uplink := "enp3s0f0np0"
+	pfPciAddress := "0000:03:00.0"
+	vfPciAddress := "0000:03:00.2"
+
+	rep, err := GetUplinkRepresentor(pfPciAddress)
+
+	if err != nil {
+		t.Fatal("GetUplinkRepresentor failed with error: ", err)
+	}
+
+	if rep != uplink {
+		t.Fatal("Actual Representor does not match expected Representor", rep, "!=", uplink)
+	}
+
+	rep, err := GetUplinkRepresentor(vfPciAddress)
+
+	if err != nil {
+		t.Fatal("GetUplinkRepresentor failed with error: ", err)
+	}
+
+	if rep != uplink {
+		t.Fatal("Actual Representor does not match expected Representor", rep, "!=", uplink)
+	}
+}

--- a/sriovnet_switchdev_test.go
+++ b/sriovnet_switchdev_test.go
@@ -145,6 +145,21 @@ func TestGetUplinkRepresentorWithoutPhysPortNameSuccess(t *testing.T) {
 	assert.Equal(t, "eth0", uplinkNetdev)
 }
 
+func TestGetUplinkRepresentorForPfSuccess(t *testing.T) {
+	pfPciAddress := "0000:03:00.0"
+	uplinkRep := &repContext{"eth0", "p0", "111111"}
+
+	vfPciAddress := ""
+	var vfsReps []*repContext
+
+	teardown := setupUplinkRepresentorEnv(t, uplinkRep, vfPciAddress, vfsReps)
+	_ = utilfs.Fs.MkdirAll(filepath.Join(PciSysDir, pfPciAddress, "net", uplinkRep.Name), os.FileMode(0755))
+	defer teardown()
+	uplinkNetdev, err := GetUplinkRepresentor(pfPciAddress)
+	assert.NoError(t, err)
+	assert.Equal(t, "eth0", uplinkNetdev)
+}
+
 func TestGetUplinkRepresentorWithPhysPortNameFailed(t *testing.T) {
 	vfPciAddress := "0000:03:00.4"
 	uplinkRep := &repContext{"eth0", "invalid", "111111"}


### PR DESCRIPTION
Currently `GetUplinkRepresentor` only works if it receives a VF pci address as an argument. The proposed change allows to get uplink representor name for PFs