### PR TITLE
Trim spaces when reading sfnum file in GetSfIndexByAuxDev()

### DIFF
--- a/sriovnet_aux.go
+++ b/sriovnet_aux.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	utilfs "github.com/Mellanox/sriovnet/pkg/utils/filesystem"
 )
@@ -47,7 +48,7 @@ func GetSfIndexByAuxDev(auxDev string) (int, error) {
 		return -1, fmt.Errorf("cannot read sfnum file for %s device: %v", auxDev, err)
 	}
 
-	sfnum, err := strconv.Atoi(string(sfNumStr))
+	sfnum, err := strconv.Atoi(strings.TrimSpace(string(sfNumStr)))
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
Not triming spaces make Atoi to fail with error, because all sysfs files
includes '\n' character.
Fix that.

Signed-of-by: Dmytro Linkin <dlinkin@nvidia.com>