### PR TITLE
Add GetSfRepresentorDPU

### DIFF
--- a/sriovnet_integration_test.go
+++ b/sriovnet_integration_test.go
@@ -238,6 +238,18 @@ func TestIntegrationGetVfRepresentorSmartNIC(t *testing.T) {
 	t.Log("VF Representor: ", rep)
 }
 
+func TestIntegrationGetSfRepresentorSmartNIC(t *testing.T) {
+	pfID := "0"
+	sfIdx := "1"
+	t.Log("GetSfRepresentorDPU ", "PF ID: ", pfID, "SF Index: ", sfIdx)
+	rep, err := GetSfRepresentorDPU(pfID, sfIdx)
+	if err != nil {
+		t.Log("GetSfRepresentorDPU ", "Error: ", err)
+		t.Fatal()
+	}
+	t.Log("SF Representor: ", rep)
+}
+
 func TestIntegrationGetRepresentorPortFlavour(t *testing.T) {
 	tcases := []struct {
 		netdev          string

--- a/sriovnet_switchdev_test.go
+++ b/sriovnet_switchdev_test.go
@@ -447,6 +447,56 @@ func TestGetVfRepresentorDPUInvalidVfIndex(t *testing.T) {
 	assert.Equal(t, "", vfRep)
 }
 
+func TestGetSfRepresentorDPUSuccess(t *testing.T) {
+	sfReps := []*repContext{
+		{
+			Name:         "eth0",
+			PhysPortName: "pf1sf0",
+			PhysSwitchID: "c2cfc60003a1420c",
+		},
+		{
+			Name:         "eth1",
+			PhysPortName: "pf1sf1",
+			PhysSwitchID: "c2cfc60003a1420c",
+		},
+		{
+			Name:         "eth2",
+			PhysPortName: "pf1sf2",
+			PhysSwitchID: "c2cfc60003a1420c",
+		},
+	}
+	teardown := setupSfRepresentorEnv(t, sfReps)
+	defer teardown()
+	sfRep, err := GetSfRepresentorDPU("1", "1")
+	assert.NoError(t, err)
+	assert.Equal(t, "eth1", sfRep)
+}
+
+func TestGetSfRepresentorDPUErrorNoRep(t *testing.T) {
+	sfReps := []*repContext{
+		{PhysPortName: "pf1sf0"},
+		{PhysPortName: "pf1sf1"},
+	}
+	teardown := setupSfRepresentorEnv(t, sfReps)
+	defer teardown()
+
+	sfRep, err := GetSfRepresentorDPU("1", "2")
+	assert.Error(t, err)
+	assert.Equal(t, "", sfRep)
+}
+
+func TestGetSfRepresentorDPUErrorInvalidPfID(t *testing.T) {
+	sfRep, err := GetSfRepresentorDPU("invalid", "3")
+	assert.Error(t, err)
+	assert.Equal(t, "", sfRep)
+}
+
+func TestGetSfRepresentorDPUErrorInvalidSfIndex(t *testing.T) {
+	sfRep, err := GetSfRepresentorDPU("1", "invalid")
+	assert.Error(t, err)
+	assert.Equal(t, "", sfRep)
+}
+
 func TestGetVfRepresentorPortFlavour(t *testing.T) {
 	vfReps := []*repContext{
 		{


### PR DESCRIPTION
Add method to retrieve SF representor name by PF index and SF index

Signed-off-by: Dmytro Linkin <dlinkin@nvidia.com>