### PR TITLE
chore: simplify GetVfRepresentor function

### DIFF
--- a/sriovnet_helper.go
+++ b/sriovnet_helper.go
@@ -117,15 +117,6 @@ func vfPCIDevNameFromVfIndex(pfNetdevName string, vfIndex int) (string, error) {
 	return pciAddress, err
 }
 
-func getPCIFromDeviceName(netdevName string) (string, error) {
-	symbolicLink := filepath.Join(NetSysDir, netdevName, pcidevPrefix)
-	pciAddress, err := readPCIsymbolicLink(symbolicLink)
-	if err != nil {
-		err = fmt.Errorf("%v for netdevice %s", err, netdevName)
-	}
-	return pciAddress, err
-}
-
 func GetVfPciDevList(pfNetdevName string) ([]string, error) {
 	var i int
 	devDirName := netDevDeviceDir(pfNetdevName)


### PR DESCRIPTION
    with kernel change introduced 5+ years ago [1]
    representor netdevs are now linked to the uplink
    physical device. meaning they will appear under
    /sys/class/net/<uplink>/device/net folder
    
    this folder contains all network devices linked to the
    physical device (typically a PCI physical function)
    
    In addition, doing this cleanup would allow to support
    multi-socket NICs where a single NIC device is connected
    to multiple PCI slots on the host. representors from either
    PF (same or different slot) of the same NIC would return the
    same physical switch ID which may cause the return of the wrong
    representor.
    
    [1] https://github.com/torvalds/linux/commit/123f0f53dd64b67e34142485fe866a8a581f12f1