### PR TITLE
chore: version bumps

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,10 +2,6 @@ on: [push, pull_request]
 name: build
 jobs:
   build:
-    strategy:
-      matrix:
-        go-version: [1.23.x]
-        goarch: [amd64]
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
@@ -14,10 +10,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.25.x
 
       - name: Build
-        env:
-          GOARCH: ${{ matrix.goarch }}
         run: make build
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,16 +2,12 @@ on: [push, pull_request]
 name: test
 jobs:
   test:
-    strategy:
-      matrix:
-        go-version: [1.23.x]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.25.x
 
       - name: Checkout code
         uses: actions/checkout@v6
@@ -30,7 +26,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.23.x
+          go-version: 1.25.x
 
       - name: Checkout code
         uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,9 @@ MOCKERY := $(BIN_DIR)/mockery
 # golangci-lint version should be updated periodically
 # we keep it fixed to avoid it from unexpectedly failing on the project
 # in case of a version bump
-GOLANGCI_LINT_VER := v2.3.0
+GOLANGCI_LINT_VER := v2.11.4
+GCOV2LCOV_VER := v1.1.1
+MOCKERY_VER := v3.7.0
 
 Q = $(if $(filter 1,$V),,@)
 
@@ -53,10 +55,10 @@ $(GOLANGCI_LINT): | $(BIN_DIR) ; $(info  building golangci-lint...)
 	$Q GOBIN=$(BIN_DIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VER)
 
 $(GCOV2LCOV):  | $(BIN_DIR) ; $(info  building gocov2lcov...)
-	$Q GOBIN=$(BIN_DIR) go install github.com/jandelgado/gcov2lcov@v1.0.5
+	$Q GOBIN=$(BIN_DIR) go install github.com/jandelgado/gcov2lcov@$(GCOV2LCOV_VER)
 
 $(MOCKERY): | $(BIN_DIR) ; $(info  building mockery...)
-	$Q GOBIN=$(BIN_DIR) go install github.com/vektra/mockery/v3@v3.5.3
+	$Q GOBIN=$(BIN_DIR) go install github.com/vektra/mockery/v3@$(MOCKERY_VER)
 
 # Misc
 .PHONY: clean

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8snetworkplumbingwg/sriovnet
 
-go 1.23.0
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
- bump go to 1.25
- bump golangci-lint to v2.11.4
- bump gocov2lcov to v1.1.1
- bump mockery to v3.7.0