### PR TITLE
fix: get/set representor peer mac address

### DIFF
--- a/pkg/utils/netlinkops/mocks/mocks.go
+++ b/pkg/utils/netlinkops/mocks/mocks.go
@@ -223,6 +223,75 @@ func (_c *MockNetlinkOps_DevLinkGetPortByNetdevName_Call) RunAndReturn(run func(
 	return _c
 }
 
+// DevLinkPortFnSet provides a mock function for the type MockNetlinkOps
+func (_mock *MockNetlinkOps) DevLinkPortFnSet(busName string, deviceName string, portIndex uint32, fnAttrs netlink.DevlinkPortFnSetAttrs) error {
+	ret := _mock.Called(busName, deviceName, portIndex, fnAttrs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DevLinkPortFnSet")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, string, uint32, netlink.DevlinkPortFnSetAttrs) error); ok {
+		r0 = returnFunc(busName, deviceName, portIndex, fnAttrs)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockNetlinkOps_DevLinkPortFnSet_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DevLinkPortFnSet'
+type MockNetlinkOps_DevLinkPortFnSet_Call struct {
+	*mock.Call
+}
+
+// DevLinkPortFnSet is a helper method to define mock.On call
+//   - busName string
+//   - deviceName string
+//   - portIndex uint32
+//   - fnAttrs netlink.DevlinkPortFnSetAttrs
+func (_e *MockNetlinkOps_Expecter) DevLinkPortFnSet(busName interface{}, deviceName interface{}, portIndex interface{}, fnAttrs interface{}) *MockNetlinkOps_DevLinkPortFnSet_Call {
+	return &MockNetlinkOps_DevLinkPortFnSet_Call{Call: _e.mock.On("DevLinkPortFnSet", busName, deviceName, portIndex, fnAttrs)}
+}
+
+func (_c *MockNetlinkOps_DevLinkPortFnSet_Call) Run(run func(busName string, deviceName string, portIndex uint32, fnAttrs netlink.DevlinkPortFnSetAttrs)) *MockNetlinkOps_DevLinkPortFnSet_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 uint32
+		if args[2] != nil {
+			arg2 = args[2].(uint32)
+		}
+		var arg3 netlink.DevlinkPortFnSetAttrs
+		if args[3] != nil {
+			arg3 = args[3].(netlink.DevlinkPortFnSetAttrs)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockNetlinkOps_DevLinkPortFnSet_Call) Return(err error) *MockNetlinkOps_DevLinkPortFnSet_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockNetlinkOps_DevLinkPortFnSet_Call) RunAndReturn(run func(busName string, deviceName string, portIndex uint32, fnAttrs netlink.DevlinkPortFnSetAttrs) error) *MockNetlinkOps_DevLinkPortFnSet_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // LinkByName provides a mock function for the type MockNetlinkOps
 func (_mock *MockNetlinkOps) LinkByName(name string) (netlink.Link, error) {
 	ret := _mock.Called(name)

--- a/pkg/utils/netlinkops/netlinkops.go
+++ b/pkg/utils/netlinkops/netlinkops.go
@@ -33,6 +33,8 @@ type NetlinkOps interface {
 	DevLinkGetPortByNetdevName(netdev string) (*netlink.DevlinkPort, error)
 	// DevLinkGetDevicePortList gets all devlink ports for a bus and device names
 	DevLinkGetDevicePortList(busName string, deviceName string) ([]*netlink.DevlinkPort, error)
+	// DevLinkPortFnSet sets devlink port function attributes
+	DevLinkPortFnSet(busName string, deviceName string, portIndex uint32, fnAttrs netlink.DevlinkPortFnSetAttrs) error
 }
 
 // GetNetlinkOps returns NetlinkOps interface
@@ -130,4 +132,9 @@ func (nlo *netlinkOps) DevLinkGetDevicePortList(busName string, deviceName strin
 	}
 
 	return devicePorts, nil
+}
+
+// DevLinkPortFnSet sets devlink port function attributes
+func (nlo *netlinkOps) DevLinkPortFnSet(busName string, deviceName string, portIndex uint32, fnAttrs netlink.DevlinkPortFnSetAttrs) error {
+	return netlink.DevlinkPortFnSet(busName, deviceName, portIndex, fnAttrs)
 }

--- a/sriovnet_switchdev.go
+++ b/sriovnet_switchdev.go
@@ -26,6 +26,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/vishvananda/netlink"
+
 	utilfs "github.com/k8snetworkplumbingwg/sriovnet/pkg/utils/filesystem"
 	"github.com/k8snetworkplumbingwg/sriovnet/pkg/utils/netlinkops"
 )
@@ -286,8 +288,8 @@ func getNetDevPhysPortName(netDev string) (string, error) {
 
 // findNetdevWithPortNameCriteria returns representor netdev that matches a criteria function on the
 // physical port name
-func findNetdevWithPortNameCriteria(criteria func(string) bool) (string, error) {
-	netdevs, err := utilfs.Fs.ReadDir(NetSysDir)
+func findNetdevWithPortNameCriteria(netdir string, criteria func(string) bool) (string, error) {
+	netdevs, err := utilfs.Fs.ReadDir(netdir)
 	if err != nil {
 		return "", err
 	}
@@ -372,7 +374,7 @@ func GetVfRepresentorDPU(pfID, vfIndex string) (string, error) {
 	// match port name with external controller index
 	// NOTE: no support for Multi-Chassis DPUs
 	expectedPhysPortName := fmt.Sprintf("c1pf%svf%s", pfID, vfIndex)
-	netdev, err := findNetdevWithPortNameCriteria(func(portName string) bool {
+	netdev, err := findNetdevWithPortNameCriteria(NetSysDir, func(portName string) bool {
 		return portName == expectedPhysPortName
 	})
 
@@ -383,7 +385,7 @@ func GetVfRepresentorDPU(pfID, vfIndex string) (string, error) {
 	// match port name without controller index (legacy)
 	// NOTE: here we assume the only VF representors on the DPU are for host VFs (and not for local VFs).
 	expectedPhysPortName = fmt.Sprintf("pf%svf%s", pfID, vfIndex)
-	netdev, err = findNetdevWithPortNameCriteria(func(portName string) bool {
+	netdev, err = findNetdevWithPortNameCriteria(NetSysDir, func(portName string) bool {
 		return portName == expectedPhysPortName
 	})
 
@@ -409,7 +411,7 @@ func GetSfRepresentorDPU(pfID, sfIndex string) (string, error) {
 	// match port name with external controller index
 	// NOTE: no support for Multi-Chassis DPUs
 	expectedPhysPortName := fmt.Sprintf("c1pf%ssf%s", pfID, sfIndex)
-	netdev, err := findNetdevWithPortNameCriteria(func(portName string) bool {
+	netdev, err := findNetdevWithPortNameCriteria(NetSysDir, func(portName string) bool {
 		return portName == expectedPhysPortName
 	})
 
@@ -430,7 +432,7 @@ func GetPfRepresentorDPU(pfID string) (string, error) {
 	// match port name with external controller index
 	// NOTE: no support for Multi-Chassis DPUs
 	expectedPhysPortName := fmt.Sprintf("c1pf%s", pfID)
-	netdev, err := findNetdevWithPortNameCriteria(func(portName string) bool {
+	netdev, err := findNetdevWithPortNameCriteria(NetSysDir, func(portName string) bool {
 		return portName == expectedPhysPortName
 	})
 
@@ -440,7 +442,7 @@ func GetPfRepresentorDPU(pfID string) (string, error) {
 
 	// match port name without controller index (legacy)
 	expectedPhysPortName = fmt.Sprintf("pf%s", pfID)
-	netdev, err = findNetdevWithPortNameCriteria(func(portName string) bool {
+	netdev, err = findNetdevWithPortNameCriteria(NetSysDir, func(portName string) bool {
 		return portName == expectedPhysPortName
 	})
 
@@ -550,10 +552,9 @@ func GetRepresentorPeerMacAddress(netdev string) (net.HardwareAddr, error) {
 			portName, netdev)
 	}
 	uplinkPhysPortName := "p" + portNum[1]
-	// Find uplink netdev for that port
-	// Note(adrianc): As we support only DPUs ATM we do not need to deal with netdevs from different
-	// eswitch (i.e different switch IDs).
-	uplinkNetdev, err := findNetdevWithPortNameCriteria(func(pname string) bool { return pname == uplinkPhysPortName })
+	// Find uplink netdev for that port, using the parent device net dir
+	netdir := filepath.Join(NetSysDir, netdev, "device", "net")
+	uplinkNetdev, err := findNetdevWithPortNameCriteria(netdir, func(pname string) bool { return pname == uplinkPhysPortName })
 	if err != nil {
 		return nil, fmt.Errorf("failed to find uplink port for netdev %s. %v", netdev, err)
 	}
@@ -592,6 +593,22 @@ func SetRepresentorPeerMacAddress(netdev string, mac net.HardwareAddr) error {
 		return fmt.Errorf("unsupported port flavour for netdev %s", netdev)
 	}
 
+	// attempt to set MAC address via devlink
+	port, err := netlinkops.GetNetlinkOps().DevLinkGetPortByNetdevName(netdev)
+	if err == nil {
+		// devlink port found, attempt to set MAC address via devlink
+		fnAttrs := netlink.DevlinkPortFnSetAttrs{
+			FnAttrs: netlink.DevlinkPortFn{
+				HwAddr: mac,
+			},
+			HwAddrValid: true,
+		}
+		if err := netlinkops.GetNetlinkOps().DevLinkPortFnSet(port.BusName, port.DeviceName, port.PortIndex, fnAttrs); err == nil {
+			return nil
+		}
+	}
+
+	// fallback to set MAC address via sysfs
 	physPortNameStr, err := getNetDevPhysPortName(netdev)
 	if err != nil {
 		return fmt.Errorf("failed to get phys_port_name for netdev %s: %v", netdev, err)
@@ -603,7 +620,9 @@ func SetRepresentorPeerMacAddress(netdev string, mac net.HardwareAddr) error {
 	}
 
 	uplinkPhysPortName := fmt.Sprintf("p%d", pfID)
-	uplinkNetdev, err := findNetdevWithPortNameCriteria(func(pname string) bool { return pname == uplinkPhysPortName })
+	// Find uplink netdev for that port, using the parent device net dir
+	netdir := filepath.Join(NetSysDir, netdev, "device", "net")
+	uplinkNetdev, err := findNetdevWithPortNameCriteria(netdir, func(pname string) bool { return pname == uplinkPhysPortName })
 	if err != nil {
 		return fmt.Errorf("failed to find netdev for physical port name %s. %v", uplinkPhysPortName, err)
 	}

--- a/sriovnet_switchdev_test.go
+++ b/sriovnet_switchdev_test.go
@@ -1270,6 +1270,11 @@ MaxTxRate  : 0
 State      : Follow
 `
 	setupDPUConfigFileForPort(t, "p0", "pf", repConfigFile)
+
+	// The uplink "p0" is now searched in the parent device net dir of "pf0hpf"
+	err := utilfs.Fs.MkdirAll(filepath.Join(NetSysDir, "pf0hpf", "device", "net", "p0"), os.FileMode(0755))
+	assert.NoError(t, err)
+
 	// Run test
 	tcases := []struct {
 		name        string
@@ -1406,6 +1411,16 @@ func TestSetRepresentorPeerMacAddress(t *testing.T) {
 			_, err := utilfs.Fs.Create(macFile)
 			assert.NoError(t, err)
 
+			// Create parent device net dir so the uplink can be found via the sysfs fallback path
+			parentNetDir := filepath.Join(NetSysDir, tcase.netdev, "device", "net")
+			err = utilfs.Fs.MkdirAll(parentNetDir, os.FileMode(0755))
+			assert.NoError(t, err)
+			// create representors in the parent net dir
+			for _, rep := range tcase.reps {
+				err = utilfs.Fs.MkdirAll(filepath.Join(parentNetDir, rep.Name), os.FileMode(0755))
+				assert.NoError(t, err)
+			}
+
 			// execute test
 			err = SetRepresentorPeerMacAddress(tcase.netdev, mac)
 			if tcase.shouldFail {
@@ -1416,6 +1431,98 @@ func TestSetRepresentorPeerMacAddress(t *testing.T) {
 				content, err := utilfs.Fs.ReadFile(macFile)
 				assert.NoError(t, err)
 				assert.Equal(t, mac.String(), string(content))
+			}
+		})
+	}
+}
+
+func TestSetRepresentorPeerMacAddressDevlink(t *testing.T) {
+	mac := net.HardwareAddr{0, 0, 0, 1, 2, 3}
+
+	dlport := &netlink.DevlinkPort{
+		BusName:     "pci",
+		DeviceName:  "0000:03:00.0",
+		PortIndex:   1,
+		PortFlavour: uint16(PORT_FLAVOUR_PCI_VF),
+	}
+
+	fnAttrs := netlink.DevlinkPortFnSetAttrs{
+		FnAttrs:     netlink.DevlinkPortFn{HwAddr: mac},
+		HwAddrValid: true,
+	}
+
+	tcases := []struct {
+		name            string
+		netdev          string
+		reps            []*repContext
+		macFile         string // sysfs mac file path to create; empty means no sysfs setup
+		devlinkFnSetErr error
+		expectedMac     string
+		shouldFail      bool
+	}{
+		{
+			name:   "devlink set succeeds",
+			netdev: "pf0vf5",
+			reps: []*repContext{
+				{Name: "pf0vf5", PhysPortName: "pf0vf5", PhysSwitchID: "c2cfc60003a1420c"},
+			},
+			macFile:         "",
+			devlinkFnSetErr: nil,
+			shouldFail:      false,
+		},
+		{
+			name:   "devlink set fails fallback to sysfs",
+			netdev: "pf0vf5",
+			reps: []*repContext{
+				{Name: "pf0vf5", PhysPortName: "pf0vf5", PhysSwitchID: "c2cfc60003a1420c"},
+				{Name: "p0", PhysPortName: "p0", PhysSwitchID: "c2cfc60003a1420c"},
+			},
+			macFile:         filepath.Join(NetSysDir, "p0", "smart_nic", "vf5", "mac"),
+			devlinkFnSetErr: fmt.Errorf("devlink set failed"),
+			expectedMac:     mac.String(),
+			shouldFail:      false,
+		},
+	}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			teardown := setupRepresentorEnv(t, "", tcase.reps)
+			defer teardown()
+
+			nlOpsMock := netlinkopsMocks.NewMockNetlinkOps(t)
+			netlinkops.SetNetlinkOps(nlOpsMock)
+			defer netlinkops.ResetNetlinkOps()
+
+			if tcase.macFile != "" {
+				// setup sysfs mac file and parent device net dir for uplink lookup
+				err := utilfs.Fs.MkdirAll(filepath.Dir(tcase.macFile), os.FileMode(0755))
+				assert.NoError(t, err)
+				_, err = utilfs.Fs.Create(tcase.macFile)
+				assert.NoError(t, err)
+
+				parentNetDir := filepath.Join(NetSysDir, tcase.netdev, "device", "net")
+				err = utilfs.Fs.MkdirAll(parentNetDir, os.FileMode(0755))
+				assert.NoError(t, err)
+				for _, rep := range tcase.reps {
+					err = utilfs.Fs.MkdirAll(filepath.Join(parentNetDir, rep.Name), os.FileMode(0755))
+					assert.NoError(t, err)
+				}
+			}
+
+			nlOpsMock.On("DevLinkGetPortByNetdevName", tcase.netdev).Return(dlport, nil)
+			nlOpsMock.On("DevLinkPortFnSet", dlport.BusName, dlport.DeviceName, dlport.PortIndex, fnAttrs).
+				Return(tcase.devlinkFnSetErr)
+
+			err := SetRepresentorPeerMacAddress(tcase.netdev, mac)
+			if tcase.shouldFail {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				if tcase.macFile != "" {
+					content, err := utilfs.Fs.ReadFile(tcase.macFile)
+					assert.NoError(t, err)
+					assert.Equal(t, tcase.expectedMac, string(content))
+				}
 			}
 		})
 	}


### PR DESCRIPTION
1. search for the uplink representor from the parent device net dir

this is needed in case a DPU has multiple ECPFs exposed from either additional external controllers or from additional devices.

2. use devlink to set the peer mac address when possible to reduce dependency on vendor-specific sysfs paths.