### PR TITLE
feat: use devlink to get port index

### DIFF
--- a/sriovnet_switchdev.go
+++ b/sriovnet_switchdev.go
@@ -313,6 +313,30 @@ func findNetdevWithPortNameCriteria(criteria func(string) bool) (string, error) 
 	return "", fmt.Errorf("no representor matched criteria")
 }
 
+// getPortIndexDevlink returns the port index of a representor from its devlink port.
+// It supports VF and SF representor port flavors.
+func getPortIndexDevlink(repNetDev string) (int, error) {
+	port, err := netlinkops.GetNetlinkOps().DevLinkGetPortByNetdevName(repNetDev)
+	if err != nil {
+		return 0, err
+	}
+
+	switch port.PortFlavour {
+	case PORT_FLAVOUR_PCI_VF:
+		if port.VfNumber == nil {
+			return 0, fmt.Errorf("unexpected result from netlink. devlink port of type vf has no vf number")
+		}
+		return int(*port.VfNumber), nil
+	case PORT_FLAVOUR_PCI_SF:
+		if port.SfNumber == nil {
+			return 0, fmt.Errorf("unexpected result from netlink. devlink port of type sf has no sf number")
+		}
+		return int(*port.SfNumber), nil
+	default:
+		return 0, fmt.Errorf("unsupported port flavour %d for netdev %s", port.PortFlavour, repNetDev)
+	}
+}
+
 // GetPortIndexFromRepresentor finds the index of a representor from its network device name.
 // Supports VF and SF. For multiple port flavors, the same ID could be returned, i.e.
 //
@@ -329,6 +353,12 @@ func GetPortIndexFromRepresentor(repNetDev string) (int, error) {
 		return 0, fmt.Errorf("unsupported port flavor for netdev %s", repNetDev)
 	}
 
+	// try to get port index from devlink
+	if portIndex, err := getPortIndexDevlink(repNetDev); err == nil {
+		return portIndex, nil
+	}
+
+	// fallback to sysfs
 	physPortName, err := getNetDevPhysPortName(repNetDev)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get device %s physical port name: %v", repNetDev, err)

--- a/sriovnet_switchdev_test.go
+++ b/sriovnet_switchdev_test.go
@@ -1021,6 +1021,110 @@ func TestGetPortIndexFromRepresentor(t *testing.T) {
 	}
 }
 
+func TestGetPortIndexFromRepresentorDevlink(t *testing.T) {
+	tcases := []struct {
+		name          string
+		netdev        string
+		reps          []*repContext
+		devlinkPort   *netlink.DevlinkPort
+		expectedID    int
+		shouldFail    bool
+		expectedError string
+	}{
+		{
+			name:   "VF rep index from devlink",
+			netdev: "eth5",
+			reps: []*repContext{
+				{Name: "eth5", PhysPortName: "pf0vf5", PhysSwitchID: "c2cfc60003a1420c"},
+			},
+			devlinkPort: &netlink.DevlinkPort{
+				NetdeviceName:    "eth5",
+				PortFlavour:      uint16(PORT_FLAVOUR_PCI_VF),
+				ControllerNumber: ptrTo(uint32(0)),
+				VfNumber:         ptrTo(uint16(5)),
+			},
+			expectedID: 5,
+		},
+		{
+			name:   "SF rep index from devlink",
+			netdev: "eth5",
+			reps: []*repContext{
+				{Name: "eth5", PhysPortName: "pf0sf5", PhysSwitchID: "c2cfc60003a1420c"},
+			},
+			devlinkPort: &netlink.DevlinkPort{
+				NetdeviceName:    "eth5",
+				PortFlavour:      uint16(PORT_FLAVOUR_PCI_SF),
+				ControllerNumber: ptrTo(uint32(0)),
+				SfNumber:         ptrTo(uint32(5)),
+			},
+			expectedID: 5,
+		},
+		{
+			name:   "devlink takes precedence over phys_port_name",
+			netdev: "eth5",
+			reps: []*repContext{
+				// phys_port_name says vf=99, devlink reports vf=5
+				{Name: "eth5", PhysPortName: "pf0vf99", PhysSwitchID: "c2cfc60003a1420c"},
+			},
+			devlinkPort: &netlink.DevlinkPort{
+				NetdeviceName: "eth5",
+				PortFlavour:   uint16(PORT_FLAVOUR_PCI_VF),
+				VfNumber:      ptrTo(uint16(5)),
+			},
+			expectedID: 5,
+		},
+		{
+			name:   "VF rep with nil VfNumber falls back to sysfs",
+			netdev: "eth5",
+			reps: []*repContext{
+				{Name: "eth5", PhysPortName: "pf0vf5", PhysSwitchID: "c2cfc60003a1420c"},
+			},
+			devlinkPort: &netlink.DevlinkPort{
+				NetdeviceName: "eth5",
+				PortFlavour:   uint16(PORT_FLAVOUR_PCI_VF),
+				VfNumber:      nil,
+			},
+			expectedID: 5,
+		},
+		{
+			name:   "SF rep with nil SfNumber falls back to sysfs",
+			netdev: "eth5",
+			reps: []*repContext{
+				{Name: "eth5", PhysPortName: "pf0sf5", PhysSwitchID: "c2cfc60003a1420c"},
+			},
+			devlinkPort: &netlink.DevlinkPort{
+				NetdeviceName: "eth5",
+				PortFlavour:   uint16(PORT_FLAVOUR_PCI_SF),
+				SfNumber:      nil,
+			},
+			expectedID: 5,
+		},
+	}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			teardown := setupRepresentorEnv(t, "", tcase.reps)
+			defer teardown()
+
+			nlOpsMock := netlinkopsMocks.NewMockNetlinkOps(t)
+			netlinkops.SetNetlinkOps(nlOpsMock)
+			defer netlinkops.ResetNetlinkOps()
+
+			nlOpsMock.On("DevLinkGetPortByNetdevName", mock.AnythingOfType("string")).Return(
+				tcase.devlinkPort, nil)
+
+			portID, err := GetPortIndexFromRepresentor(tcase.netdev)
+			if tcase.shouldFail {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tcase.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tcase.expectedID, portID)
+			}
+		})
+	}
+}
+
 func TestGetSfRepresentorDPU(t *testing.T) {
 	tcases := []struct {
 		name          string


### PR DESCRIPTION
use devlink in GetPortIndexFromRepresentor to
get the port index. fallback to sysfs in case
of failure.