### PR TITLE
feat: representor port params

### DIFF
--- a/sriovnet_dpu.go
+++ b/sriovnet_dpu.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sriovnet
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/vishvananda/netlink"
+
+	"github.com/k8snetworkplumbingwg/sriovnet/pkg/utils/netlinkops"
+)
+
+// RepresentorPortParams contains the base port parameters for locating representors.
+type RepresentorPortParams struct {
+	// The PCI device address on which the representor is anchored
+	ECPF string
+	// The controller number
+	ControllerNumber uint32
+	// The PF number
+	PFNumber uint16
+}
+
+// GetVfRepresentorFromPortParams returns the VF representor netdev name for a given port parameters and VF index
+func GetVfRepresentorFromPortParams(pp *RepresentorPortParams, vfIndex uint32) (string, error) {
+	if pp == nil {
+		return "", fmt.Errorf("port parameters are nil")
+	}
+
+	rep, err := getRepresentorDevlink(pp.ECPF, PORT_FLAVOUR_PCI_VF, pp.ControllerNumber, vfIndex, &pp.PFNumber)
+	if err != nil {
+		return "", fmt.Errorf("failed to get representor netdev name for VF %d: %w", vfIndex, err)
+	}
+	return rep, nil
+}
+
+// GetSfRepresentorFromPortParams returns the SF representor netdev name for a given port parameters and SF index
+func GetSfRepresentorFromPortParams(pp *RepresentorPortParams, sfIndex uint32) (string, error) {
+	if pp == nil {
+		return "", fmt.Errorf("port parameters are nil")
+	}
+
+	rep, err := getRepresentorDevlink(pp.ECPF, PORT_FLAVOUR_PCI_SF, pp.ControllerNumber, sfIndex, &pp.PFNumber)
+	if err != nil {
+		return "", fmt.Errorf("failed to get representor netdev name for SF %d: %w", sfIndex, err)
+	}
+	return rep, nil
+}
+
+// GetPfRepresentorFromPortParams returns the PF representor netdev name for a given port parameters
+func GetPfRepresentorFromPortParams(pp *RepresentorPortParams) (string, error) {
+	if pp == nil {
+		return "", fmt.Errorf("port parameters are nil")
+	}
+
+	rep, err := getRepresentorDevlink(pp.ECPF, PORT_FLAVOUR_PCI_PF, pp.ControllerNumber, uint32(pp.PFNumber), &pp.PFNumber)
+	if err != nil {
+		return "", fmt.Errorf("failed to get representor netdev name for PF %d: %w", pp.PFNumber, err)
+	}
+	return rep, nil
+}
+
+// GetPFRepresentorPortParamsFromMAC returns the representor port parameters from the provided MAC address.
+//
+// Note: This function will work properly only when MAC addresses are unique in the system.
+// If multiple ports have the same MAC address, the function will return error.
+func GetPFRepresentorPortParamsFromMAC(mac net.HardwareAddr) (*RepresentorPortParams, error) {
+	macStr := mac.String()
+
+	if macStr == "" {
+		return nil, fmt.Errorf("invalid MAC address %s", macStr)
+	}
+
+	// list all devlink ports
+	ports, err := netlinkops.GetNetlinkOps().DevLinkGetAllPortList()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list devlink ports: %w", err)
+	}
+
+	// find the port with the given MAC address
+	var foundPorts []*netlink.DevlinkPort
+	for _, port := range ports {
+		if port.BusName != "pci" {
+			continue
+		}
+
+		if port.PortFlavour != uint16(PORT_FLAVOUR_PCI_PF) {
+			continue
+		}
+
+		if port.Fn != nil && port.Fn.HwAddr.String() == macStr {
+			foundPorts = append(foundPorts, port)
+		}
+	}
+
+	if len(foundPorts) == 0 {
+		return nil, fmt.Errorf("no matching devlink port found with MAC address %s", mac.String())
+	}
+
+	if len(foundPorts) > 1 {
+		return nil, fmt.Errorf("multiple matching(%d) devlink ports found with MAC address %s", len(foundPorts), mac.String())
+	}
+
+	port := foundPorts[0]
+	if port.DeviceName == "" || port.ControllerNumber == nil || port.PfNumber == nil {
+		return nil, fmt.Errorf("unexpected result from netlink. devlink port with MAC address %s has missing attributes", mac.String())
+	}
+
+	return &RepresentorPortParams{
+		ECPF:             port.DeviceName,
+		ControllerNumber: *port.ControllerNumber,
+		PFNumber:         *port.PfNumber,
+	}, nil
+}

--- a/sriovnet_dpu_test.go
+++ b/sriovnet_dpu_test.go
@@ -1,0 +1,780 @@
+/*
+Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sriovnet
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
+
+	"github.com/k8snetworkplumbingwg/sriovnet/pkg/utils/netlinkops"
+	netlinkopsMocks "github.com/k8snetworkplumbingwg/sriovnet/pkg/utils/netlinkops/mocks"
+)
+
+func TestGetVfRepresentorFromPortParams(t *testing.T) {
+	const ecpf = "0000:03:00.0"
+
+	tcases := []struct {
+		name          string
+		pp            *RepresentorPortParams
+		vfIndex       uint32
+		devlinkPorts  []*netlink.DevlinkPort
+		devlinkErr    error
+		expectedRep   string
+		shouldFail    bool
+		expectedError string
+	}{
+		{
+			name:          "nil port params",
+			pp:            nil,
+			vfIndex:       0,
+			shouldFail:    true,
+			expectedError: "port parameters are nil",
+		},
+		{
+			name:    "VF representor found - controller 0",
+			pp:      &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			vfIndex: 1,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					NetdeviceName:    "pf0vf0",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_VF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					VfNumber:         ptrTo(uint16(0)),
+				},
+				{
+					NetdeviceName:    "pf0vf1",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_VF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					VfNumber:         ptrTo(uint16(1)),
+				},
+			},
+			expectedRep: "pf0vf1",
+		},
+		{
+			name:    "VF representor found - external controller",
+			pp:      &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 1, PFNumber: 0},
+			vfIndex: 2,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					NetdeviceName:    "pf0vf2",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_VF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					VfNumber:         ptrTo(uint16(2)),
+				},
+				{
+					NetdeviceName:    "c1pf0vf2",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_VF),
+					ControllerNumber: ptrTo(uint32(1)),
+					PfNumber:         ptrTo(uint16(0)),
+					VfNumber:         ptrTo(uint16(2)),
+				},
+			},
+			expectedRep: "c1pf0vf2",
+		},
+		{
+			name:          "devlink returns error",
+			pp:            &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			vfIndex:       0,
+			devlinkErr:    fmt.Errorf("devlink error"),
+			expectedRep:   "",
+			shouldFail:    true,
+			expectedError: "failed to get representor netdev name for VF 0",
+		},
+		{
+			name:          "VF not found - empty list",
+			pp:            &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			vfIndex:       0,
+			devlinkPorts:  []*netlink.DevlinkPort{},
+			expectedRep:   "",
+			shouldFail:    true,
+			expectedError: "failed to get representor netdev name for VF 0",
+		},
+		{
+			name:    "VF not found - matching VF index but different PF",
+			pp:      &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			vfIndex: 0,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					NetdeviceName:    "pf1vf0",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_VF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(1)),
+					VfNumber:         ptrTo(uint16(0)),
+				},
+			},
+			shouldFail: true,
+		},
+		{
+			name:    "VF not found - matching VF index but different controller",
+			pp:      &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			vfIndex: 0,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					NetdeviceName:    "c1pf0vf0",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_VF),
+					ControllerNumber: ptrTo(uint32(1)),
+					PfNumber:         ptrTo(uint16(0)),
+					VfNumber:         ptrTo(uint16(0)),
+				},
+			},
+			shouldFail: true,
+		},
+		{
+			name:    "VF not found - only SF/PF ports",
+			pp:      &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			vfIndex: 0,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					NetdeviceName:    "pf0sf0",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_SF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					SfNumber:         ptrTo(uint32(0)),
+				},
+				{
+					NetdeviceName:    "pf0",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_PF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+				},
+			},
+			shouldFail: true,
+		},
+		{
+			name:    "VF port with nil VfNumber returns error",
+			pp:      &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			vfIndex: 0,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					NetdeviceName:    "pf0vf0",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_VF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					VfNumber:         nil,
+				},
+			},
+			shouldFail: true,
+		},
+		{
+			name:    "VF port found but empty NetdeviceName",
+			pp:      &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			vfIndex: 0,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					NetdeviceName:    "",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_VF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					VfNumber:         ptrTo(uint16(0)),
+				},
+			},
+			shouldFail: true,
+		},
+	}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			nlOpsMock := netlinkopsMocks.NewMockNetlinkOps(t)
+			netlinkops.SetNetlinkOps(nlOpsMock)
+			defer netlinkops.ResetNetlinkOps()
+
+			if tcase.pp != nil {
+				nlOpsMock.On("DevLinkGetDevicePortList", "pci", tcase.pp.ECPF).Return(
+					tcase.devlinkPorts, tcase.devlinkErr)
+			}
+
+			rep, err := GetVfRepresentorFromPortParams(tcase.pp, tcase.vfIndex)
+			if tcase.shouldFail {
+				assert.Error(t, err)
+				if tcase.expectedError != "" {
+					assert.Contains(t, err.Error(), tcase.expectedError)
+				}
+				assert.Equal(t, "", rep)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tcase.expectedRep, rep)
+			}
+		})
+	}
+}
+
+func TestGetSfRepresentorFromPortParams(t *testing.T) {
+	const ecpf = "0000:03:00.0"
+
+	tcases := []struct {
+		name          string
+		pp            *RepresentorPortParams
+		sfIndex       uint32
+		devlinkPorts  []*netlink.DevlinkPort
+		devlinkErr    error
+		expectedRep   string
+		shouldFail    bool
+		expectedError string
+	}{
+		{
+			name:          "nil port params",
+			pp:            nil,
+			sfIndex:       0,
+			shouldFail:    true,
+			expectedError: "port parameters are nil",
+		},
+		{
+			name:    "SF representor found - controller 0",
+			pp:      &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			sfIndex: 5,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					NetdeviceName:    "pf0sf0",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_SF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					SfNumber:         ptrTo(uint32(0)),
+				},
+				{
+					NetdeviceName:    "pf0sf5",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_SF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					SfNumber:         ptrTo(uint32(5)),
+				},
+			},
+			expectedRep: "pf0sf5",
+		},
+		{
+			name:    "SF representor found - external controller",
+			pp:      &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 1, PFNumber: 0},
+			sfIndex: 10,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					NetdeviceName:    "pf0sf10",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_SF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					SfNumber:         ptrTo(uint32(10)),
+				},
+				{
+					NetdeviceName:    "c1pf0sf10",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_SF),
+					ControllerNumber: ptrTo(uint32(1)),
+					PfNumber:         ptrTo(uint16(0)),
+					SfNumber:         ptrTo(uint32(10)),
+				},
+			},
+			expectedRep: "c1pf0sf10",
+		},
+		{
+			name:          "devlink returns error",
+			pp:            &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			sfIndex:       0,
+			devlinkErr:    fmt.Errorf("devlink error"),
+			shouldFail:    true,
+			expectedError: "failed to get representor netdev name for SF 0",
+		},
+		{
+			name:          "SF not found - empty list",
+			pp:            &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			sfIndex:       0,
+			devlinkPorts:  []*netlink.DevlinkPort{},
+			shouldFail:    true,
+			expectedError: "failed to get representor netdev name for SF 0",
+		},
+		{
+			name:    "SF not found - matching SF index but different PF",
+			pp:      &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			sfIndex: 5,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					NetdeviceName:    "pf1sf5",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_SF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(1)),
+					SfNumber:         ptrTo(uint32(5)),
+				},
+			},
+			shouldFail: true,
+		},
+		{
+			name:    "SF not found - only VF/PF ports",
+			pp:      &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			sfIndex: 0,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					NetdeviceName:    "pf0vf0",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_VF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					VfNumber:         ptrTo(uint16(0)),
+				},
+			},
+			shouldFail: true,
+		},
+		{
+			name:    "SF port with nil SfNumber returns error",
+			pp:      &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			sfIndex: 0,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					NetdeviceName:    "pf0sf0",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_SF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					SfNumber:         nil,
+				},
+			},
+			shouldFail: true,
+		},
+	}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			nlOpsMock := netlinkopsMocks.NewMockNetlinkOps(t)
+			netlinkops.SetNetlinkOps(nlOpsMock)
+			defer netlinkops.ResetNetlinkOps()
+
+			if tcase.pp != nil {
+				nlOpsMock.On("DevLinkGetDevicePortList", "pci", tcase.pp.ECPF).Return(
+					tcase.devlinkPorts, tcase.devlinkErr)
+			}
+
+			rep, err := GetSfRepresentorFromPortParams(tcase.pp, tcase.sfIndex)
+			if tcase.shouldFail {
+				assert.Error(t, err)
+				if tcase.expectedError != "" {
+					assert.Contains(t, err.Error(), tcase.expectedError)
+				}
+				assert.Equal(t, "", rep)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tcase.expectedRep, rep)
+			}
+		})
+	}
+}
+
+func TestGetPfRepresentorFromPortParams(t *testing.T) {
+	const ecpf = "0000:03:00.0"
+
+	tcases := []struct {
+		name          string
+		pp            *RepresentorPortParams
+		devlinkPorts  []*netlink.DevlinkPort
+		devlinkErr    error
+		expectedRep   string
+		shouldFail    bool
+		expectedError string
+	}{
+		{
+			name:          "nil port params",
+			pp:            nil,
+			shouldFail:    true,
+			expectedError: "port parameters are nil",
+		},
+		{
+			name: "PF representor found - controller 0 PF 0",
+			pp:   &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					NetdeviceName:    "pf0hpf",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_PF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+				},
+				{
+					NetdeviceName:    "pf1hpf",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_PF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(1)),
+				},
+			},
+			expectedRep: "pf0hpf",
+		},
+		{
+			name: "PF representor found - external controller",
+			pp:   &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 1, PFNumber: 1},
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					NetdeviceName:    "pf1hpf",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_PF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(1)),
+				},
+				{
+					NetdeviceName:    "c1pf1",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_PF),
+					ControllerNumber: ptrTo(uint32(1)),
+					PfNumber:         ptrTo(uint16(1)),
+				},
+			},
+			expectedRep: "c1pf1",
+		},
+		{
+			name:          "devlink returns error",
+			pp:            &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			devlinkErr:    fmt.Errorf("devlink error"),
+			shouldFail:    true,
+			expectedError: "failed to get representor netdev name for PF 0",
+		},
+		{
+			name:          "PF not found - empty list",
+			pp:            &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			devlinkPorts:  []*netlink.DevlinkPort{},
+			shouldFail:    true,
+			expectedError: "failed to get representor netdev name for PF 0",
+		},
+		{
+			name: "PF not found - different controller",
+			pp:   &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					NetdeviceName:    "c1pf0",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_PF),
+					ControllerNumber: ptrTo(uint32(1)),
+					PfNumber:         ptrTo(uint16(0)),
+				},
+			},
+			shouldFail: true,
+		},
+		{
+			name: "PF not found - only VF/SF ports",
+			pp:   &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					NetdeviceName:    "pf0vf0",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_VF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					VfNumber:         ptrTo(uint16(0)),
+				},
+			},
+			shouldFail: true,
+		},
+		{
+			name: "PF port with nil PfNumber returns error",
+			pp:   &RepresentorPortParams{ECPF: ecpf, ControllerNumber: 0, PFNumber: 0},
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					NetdeviceName:    "pf0hpf",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_PF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         nil,
+				},
+			},
+			shouldFail: true,
+		},
+	}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			nlOpsMock := netlinkopsMocks.NewMockNetlinkOps(t)
+			netlinkops.SetNetlinkOps(nlOpsMock)
+			defer netlinkops.ResetNetlinkOps()
+
+			if tcase.pp != nil {
+				nlOpsMock.On("DevLinkGetDevicePortList", "pci", tcase.pp.ECPF).Return(
+					tcase.devlinkPorts, tcase.devlinkErr)
+			}
+
+			rep, err := GetPfRepresentorFromPortParams(tcase.pp)
+			if tcase.shouldFail {
+				assert.Error(t, err)
+				if tcase.expectedError != "" {
+					assert.Contains(t, err.Error(), tcase.expectedError)
+				}
+				assert.Equal(t, "", rep)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tcase.expectedRep, rep)
+			}
+		})
+	}
+}
+
+func TestGetPFRepresentorPortParamsFromMAC(t *testing.T) {
+	mac1, err := net.ParseMAC("0c:42:a1:de:cf:7c")
+	assert.NoError(t, err)
+	mac2, err := net.ParseMAC("0c:42:a1:de:cf:7d")
+	assert.NoError(t, err)
+	otherMac, err := net.ParseMAC("aa:bb:cc:dd:ee:ff")
+	assert.NoError(t, err)
+
+	tcases := []struct {
+		name          string
+		mac           net.HardwareAddr
+		devlinkPorts  []*netlink.DevlinkPort
+		devlinkErr    error
+		expectedPP    *RepresentorPortParams
+		shouldFail    bool
+		expectedError string
+	}{
+		{
+			name:          "devlink returns error",
+			mac:           mac1,
+			devlinkErr:    fmt.Errorf("devlink not available"),
+			shouldFail:    true,
+			expectedError: "failed to list devlink ports",
+		},
+		{
+			name:          "no matching port",
+			mac:           otherMac,
+			devlinkPorts:  []*netlink.DevlinkPort{},
+			shouldFail:    true,
+			expectedError: "no matching devlink port found",
+		},
+		{
+			name: "single matching PF port",
+			mac:  mac1,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					BusName:          "pci",
+					DeviceName:       "0000:03:00.0",
+					NetdeviceName:    "pf0hpf",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_PF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					Fn:               &netlink.DevlinkPortFn{HwAddr: mac1},
+				},
+			},
+			expectedPP: &RepresentorPortParams{
+				ECPF:             "0000:03:00.0",
+				ControllerNumber: 0,
+				PFNumber:         0,
+			},
+		},
+		{
+			name: "multiple matching PF ports",
+			mac:  mac1,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					BusName:          "pci",
+					DeviceName:       "0000:03:00.0",
+					NetdeviceName:    "pf0hpf",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_PF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					Fn:               &netlink.DevlinkPortFn{HwAddr: mac1},
+				},
+				{
+					BusName:          "pci",
+					DeviceName:       "0000:04:00.0",
+					NetdeviceName:    "pf0hpf",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_PF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					Fn:               &netlink.DevlinkPortFn{HwAddr: mac1},
+				},
+			},
+			shouldFail:    true,
+			expectedError: "multiple matching",
+		},
+		{
+			name: "ignores non-pci ports",
+			mac:  mac1,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					BusName:          "auxiliary",
+					DeviceName:       "mlx5_core.eth.5",
+					NetdeviceName:    "pf0hpf",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_PF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					Fn:               &netlink.DevlinkPortFn{HwAddr: mac1},
+				},
+			},
+			shouldFail:    true,
+			expectedError: "no matching devlink port found",
+		},
+		{
+			name: "ignores non-PF flavour",
+			mac:  mac1,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					BusName:          "pci",
+					DeviceName:       "0000:03:00.0",
+					NetdeviceName:    "pf0vf0",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_VF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					VfNumber:         ptrTo(uint16(0)),
+					Fn:               &netlink.DevlinkPortFn{HwAddr: mac1},
+				},
+				{
+					BusName:          "pci",
+					DeviceName:       "0000:03:00.0",
+					NetdeviceName:    "pf0sf0",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_SF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					SfNumber:         ptrTo(uint32(0)),
+					Fn:               &netlink.DevlinkPortFn{HwAddr: mac1},
+				},
+				{
+					BusName:          "pci",
+					DeviceName:       "0000:03:00.0",
+					NetdeviceName:    "p0",
+					PortFlavour:      uint16(PORT_FLAVOUR_PHYSICAL),
+					ControllerNumber: ptrTo(uint32(0)),
+					Fn:               &netlink.DevlinkPortFn{HwAddr: mac1},
+				},
+			},
+			shouldFail:    true,
+			expectedError: "no matching devlink port found",
+		},
+		{
+			name: "skips port with nil Fn",
+			mac:  mac1,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					BusName:          "pci",
+					DeviceName:       "0000:03:00.0",
+					NetdeviceName:    "pf0hpf",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_PF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					Fn:               nil,
+				},
+			},
+			shouldFail:    true,
+			expectedError: "no matching devlink port found",
+		},
+		{
+			name: "skips port with different MAC",
+			mac:  mac1,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					BusName:          "pci",
+					DeviceName:       "0000:03:00.0",
+					NetdeviceName:    "pf0hpf",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_PF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					Fn:               &netlink.DevlinkPortFn{HwAddr: mac2},
+				},
+			},
+			shouldFail:    true,
+			expectedError: "no matching devlink port found",
+		},
+		{
+			name: "matching port missing DeviceName",
+			mac:  mac1,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					BusName:          "pci",
+					DeviceName:       "",
+					NetdeviceName:    "pf0hpf",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_PF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					Fn:               &netlink.DevlinkPortFn{HwAddr: mac1},
+				},
+			},
+			shouldFail:    true,
+			expectedError: "missing attributes",
+		},
+		{
+			name: "matching port missing ControllerNumber",
+			mac:  mac1,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					BusName:          "pci",
+					DeviceName:       "0000:03:00.0",
+					NetdeviceName:    "pf0hpf",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_PF),
+					ControllerNumber: nil,
+					PfNumber:         ptrTo(uint16(0)),
+					Fn:               &netlink.DevlinkPortFn{HwAddr: mac1},
+				},
+			},
+			shouldFail:    true,
+			expectedError: "missing attributes",
+		},
+		{
+			name: "matching port missing PfNumber",
+			mac:  mac1,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					BusName:          "pci",
+					DeviceName:       "0000:03:00.0",
+					NetdeviceName:    "pf0hpf",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_PF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         nil,
+					Fn:               &netlink.DevlinkPortFn{HwAddr: mac1},
+				},
+			},
+			shouldFail:    true,
+			expectedError: "missing attributes",
+		},
+		{
+			name: "matching port - external controller",
+			mac:  mac1,
+			devlinkPorts: []*netlink.DevlinkPort{
+				{
+					BusName:          "pci",
+					DeviceName:       "0000:03:00.0",
+					NetdeviceName:    "pf0hpf",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_PF),
+					ControllerNumber: ptrTo(uint32(0)),
+					PfNumber:         ptrTo(uint16(0)),
+					Fn:               &netlink.DevlinkPortFn{HwAddr: mac2},
+				},
+				{
+					BusName:          "pci",
+					DeviceName:       "0000:03:00.0",
+					NetdeviceName:    "c1pf1",
+					PortFlavour:      uint16(PORT_FLAVOUR_PCI_PF),
+					ControllerNumber: ptrTo(uint32(1)),
+					PfNumber:         ptrTo(uint16(1)),
+					Fn:               &netlink.DevlinkPortFn{HwAddr: mac1},
+				},
+			},
+			expectedPP: &RepresentorPortParams{
+				ECPF:             "0000:03:00.0",
+				ControllerNumber: 1,
+				PFNumber:         1,
+			},
+		},
+	}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			nlOpsMock := netlinkopsMocks.NewMockNetlinkOps(t)
+			netlinkops.SetNetlinkOps(nlOpsMock)
+			defer netlinkops.ResetNetlinkOps()
+
+			nlOpsMock.On("DevLinkGetAllPortList").Return(tcase.devlinkPorts, tcase.devlinkErr)
+
+			pp, err := GetPFRepresentorPortParamsFromMAC(tcase.mac)
+			if tcase.shouldFail {
+				assert.Error(t, err)
+				if tcase.expectedError != "" {
+					assert.Contains(t, err.Error(), tcase.expectedError)
+				}
+				assert.Nil(t, pp)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tcase.expectedPP, pp)
+			}
+		})
+	}
+}

--- a/sriovnet_switchdev.go
+++ b/sriovnet_switchdev.go
@@ -184,10 +184,10 @@ func GetUplinkRepresentor(pciAddress string) (string, error) {
 	return "", fmt.Errorf("uplink for %s not found", pciAddress)
 }
 
-// getRepresentorDevlink returns the representor netdev name for a given device, portflavor, controller number and index.
-func getRepresentorDevlink(deviceName string, flavor PortFlavour, controllerNumber uint32, index uint32) (string, error) {
+// getRepresentorDevlink returns the representor netdev name for a given device, portflavor, controller number, index and  pf number(optional).
+func getRepresentorDevlink(deviceName string, flavor PortFlavour, controllerNumber uint32, index uint32, pfNum *uint16) (string, error) {
 	// check for supported flavor
-	if flavor != PORT_FLAVOUR_PCI_VF && flavor != PORT_FLAVOUR_PCI_SF {
+	if flavor != PORT_FLAVOUR_PCI_VF && flavor != PORT_FLAVOUR_PCI_SF && flavor != PORT_FLAVOUR_PCI_PF {
 		return "", fmt.Errorf("unsupported flavor %d", flavor)
 	}
 
@@ -206,23 +206,38 @@ func getRepresentorDevlink(deviceName string, flavor PortFlavour, controllerNumb
 			continue
 		}
 
-		// get devlink port sf/vf number
+		// if pfNum is specified, check that the port pf number matches.
+		if pfNum != nil && (port.PfNumber == nil || *port.PfNumber != *pfNum) {
+			continue
+		}
+
+		// get devlink port pf/sf/vf number
 		var dpIndex uint32
 		switch flavor {
+		case PORT_FLAVOUR_PCI_PF:
+			if port.PfNumber == nil {
+				return "", fmt.Errorf("unexpected result from netlink. devlink port of type pf has no pf number. pci/%s/%d", deviceName, port.PortIndex)
+			}
+			dpIndex = uint32(*port.PfNumber)
 		case PORT_FLAVOUR_PCI_VF:
 			if port.VfNumber == nil {
-				return "", fmt.Errorf("unexpected result from netlink. devlink port of type vf has not vf number. pci/%s/%d", deviceName, port.PortIndex)
+				return "", fmt.Errorf("unexpected result from netlink. devlink port of type vf has no vf number. pci/%s/%d", deviceName, port.PortIndex)
 			}
 			dpIndex = uint32(*port.VfNumber)
 		case PORT_FLAVOUR_PCI_SF:
 			if port.SfNumber == nil {
-				return "", fmt.Errorf("unexpected result from netlink. devlink port of type sf has not sf number. pci/%s/%d", deviceName, port.PortIndex)
+				return "", fmt.Errorf("unexpected result from netlink. devlink port of type sf has no sf number. pci/%s/%d", deviceName, port.PortIndex)
 			}
 			dpIndex = *port.SfNumber
 		}
 
 		if dpIndex != index {
 			continue
+		}
+
+		// we found the matching devlink port, the netdevice attribute is the representor netdev name
+		if port.NetdeviceName == "" {
+			return "", fmt.Errorf("unexpected result from netlink. devlink port of type %d has no netdevice name. pci/%s/%d", flavor, deviceName, port.PortIndex)
 		}
 
 		return port.NetdeviceName, nil
@@ -249,7 +264,7 @@ func GetVfRepresentor(uplink string, vfIndex int) (string, error) {
 	}
 
 	// try to get representor from devlink
-	representor, err := getRepresentorDevlink(uplinkPCI, PORT_FLAVOUR_PCI_VF, 0, uint32(vfIndex))
+	representor, err := getRepresentorDevlink(uplinkPCI, PORT_FLAVOUR_PCI_VF, 0, uint32(vfIndex), nil)
 	if err == nil {
 		return representor, nil
 	}
@@ -295,7 +310,7 @@ func GetSfRepresentor(uplink string, sfNum int) (string, error) {
 	}
 
 	// try to get representor from devlink
-	representor, err := getRepresentorDevlink(uplinkPCI, PORT_FLAVOUR_PCI_SF, 0, uint32(sfNum))
+	representor, err := getRepresentorDevlink(uplinkPCI, PORT_FLAVOUR_PCI_SF, 0, uint32(sfNum), nil)
 	if err == nil {
 		return representor, nil
 	}
@@ -433,6 +448,8 @@ func GetPortIndexFromRepresentor(repNetDev string) (int, error) {
 }
 
 // GetVfRepresentorDPU returns VF representor on DPU for a host VF identified by pfID and vfIndex
+//
+// Deprecated: use GetVfRepresentorFromPortParams instead.
 func GetVfRepresentorDPU(pfID, vfIndex string) (string, error) {
 	// TODO(Adrianc): This method should change to get switchID and vfIndex as input, then common logic can
 	// be shared with GetVfRepresentor, backward compatibility should be preserved when this happens.
@@ -473,6 +490,8 @@ func GetVfRepresentorDPU(pfID, vfIndex string) (string, error) {
 }
 
 // GetSfRepresentorDPU returns SF representor on DPU for a host SF identified by pfID and sfIndex
+//
+// Deprecated: use GetSfRepresentorFromPortParams instead.
 func GetSfRepresentorDPU(pfID, sfIndex string) (string, error) {
 	// pfID should be 0 or 1
 	if pfID != "0" && pfID != "1" {
@@ -499,6 +518,8 @@ func GetSfRepresentorDPU(pfID, sfIndex string) (string, error) {
 }
 
 // GetPfRepresentorDPU returns PF representor on DPU for a host PF identified by its ID.
+//
+// Deprecated: use GetPfRepresentorFromPortParams instead.
 func GetPfRepresentorDPU(pfID string) (string, error) {
 	// pfID should be 0 or 1
 	if pfID != "0" && pfID != "1" {


### PR DESCRIPTION
Introduce a new set of functions to retrieve PF/VF/SF representors for cases where DPUs are being used.

On a DPU we may have the following types of representors

1. VF/SF representors for network devices that are exposed locally on the DPU
2. PF/VF/SF representors for network devices that are exposed to an external host through one or more PCI sockets

1,2 above may belong to either the DPU hardware or external hardware connected to the DPU via dedicated PCI bus.

To properly find the representor we need to know the PF address in the DPU under which the representor is anchored (aka embedded CPU PF or ECPF).

As well as the controller number (on which host facing PCI socket) the device was exposed and the PF number of that device.

- RepresentorPortParams: a new struct that contains the above base information
- GetRepresentorPortParamsFromMAC: a function to construct RepresentorPortParams from host PF mac address
- getter functions for PF/VF/SF representors with provided RepresentorPortParams and index where applicable.
    - GetPfRepresentorFromPortParams
    - GetVfRepresentorFromPortParams
    - GetSfRepresentorFromPortParams