### PR TITLE
feat: add ErrRepresentorNotFound errors

### DIFF
--- a/sriovnet_switchdev.go
+++ b/sriovnet_switchdev.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sriovnet
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"path/filepath"
@@ -51,23 +52,25 @@ const (
 	PORT_FLAVOUR_UNKNOWN = 0xffff
 )
 
-// Regex that matches on the physical/upling port name
-var physPortRepRegex = regexp.MustCompile(`^p(\d+)$`)
+var (
+	// ErrRepresentorNotFound is returned when a representor is not found.
+	ErrRepresentorNotFound = errors.New("representor not found")
+)
 
-// Regex that matches on PF representor port name. These ports exists on DPUs and represents ports on Host.
-var pfPortRepRegex = regexp.MustCompile(`^(?:c\d+)?pf(\d+)$`)
-
-// Regex that matches on VF representor port name for a local VF.
-var vfPortRepRegex = regexp.MustCompile(`^pf(\d+)vf(\d+)$`)
-
-// Regex that matches on VF representor port name with controller index. These ports exists on DPUs. and represent VFs on Host.
-var vfPortRepRegexWithControllerIndex = regexp.MustCompile(`^c\d+pf(\d+)vf(\d+)$`)
-
-// Regex that matches on SF representor port name
-var sfPortRepRegex = regexp.MustCompile(`^pf(\d+)sf(\d+)$`)
-
-// Regex that matches on SF representor port name with controller index. These ports exists on DPUs. and represent SFs on Host.
-var sfPortRepRegexWithControllerIndex = regexp.MustCompile(`^c\d+pf(\d+)sf(\d+)$`)
+var (
+	// Regex that matches on the physical/uplink port name
+	physPortRepRegex = regexp.MustCompile(`^p(\d+)$`)
+	// Regex that matches on PF representor port name. These ports exists on DPUs and represents ports on Host.
+	pfPortRepRegex = regexp.MustCompile(`^(?:c\d+)?pf(\d+)$`)
+	// Regex that matches on VF representor port name for a local VF.
+	vfPortRepRegex = regexp.MustCompile(`^pf(\d+)vf(\d+)$`)
+	// Regex that matches on VF representor port name with controller index. These ports exists on DPUs. and represent VFs on Host.
+	vfPortRepRegexWithControllerIndex = regexp.MustCompile(`^c\d+pf(\d+)vf(\d+)$`)
+	// Regex that matches on SF representor port name
+	sfPortRepRegex = regexp.MustCompile(`^pf(\d+)sf(\d+)$`)
+	// Regex that matches on SF representor port name with controller index. These ports exists on DPUs. and represent SFs on Host.
+	sfPortRepRegexWithControllerIndex = regexp.MustCompile(`^c\d+pf(\d+)sf(\d+)$`)
+)
 
 func parseIndexFromPhysPortName(portName string, regex *regexp.Regexp) (pfRepIndex, vfRepIndex int, err error) {
 	matches := regex.FindStringSubmatch(portName)
@@ -137,7 +140,7 @@ func getUplinkRepresentorDevlink(pciAddress string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("failed to find uplink representor for %s", pciAddress)
+	return "", fmt.Errorf("failed to get uplink representor for %s: %w", pciAddress, ErrRepresentorNotFound)
 }
 
 // GetUplinkRepresentor gets a VF or PF PCI address (e.g '0000:03:00.4') and
@@ -181,7 +184,7 @@ func GetUplinkRepresentor(pciAddress string) (string, error) {
 			return device.Name(), nil
 		}
 	}
-	return "", fmt.Errorf("uplink for %s not found", pciAddress)
+	return "", fmt.Errorf("failed to get uplink representor for %s: %w", pciAddress, ErrRepresentorNotFound)
 }
 
 // getRepresentorDevlink returns the representor netdev name for a given device, portflavor, controller number, index and  pf number(optional).
@@ -243,7 +246,8 @@ func getRepresentorDevlink(deviceName string, flavor PortFlavour, controllerNumb
 		return port.NetdeviceName, nil
 	}
 
-	return "", fmt.Errorf("failed to find representor for: device %s, flavor %d, controller %d, index %d", deviceName, flavor, controllerNumber, index)
+	return "", fmt.Errorf("failed to get representor via devlink: device %s, flavor %d, controller %d, index %d: %w",
+		deviceName, flavor, controllerNumber, index, ErrRepresentorNotFound)
 }
 
 // GetVfRepresentor returns the VF representor netdev name for a given uplink netdev and vfIndex.
@@ -293,7 +297,7 @@ func GetVfRepresentor(uplink string, vfIndex int) (string, error) {
 			return device.Name(), nil
 		}
 	}
-	return "", fmt.Errorf("failed to find VF representor for uplink %s, vfIndex %d", uplink, vfIndex)
+	return "", fmt.Errorf("failed to get VF representor for uplink %s, vfIndex %d: %w", uplink, vfIndex, ErrRepresentorNotFound)
 }
 
 // GetSfRepresentor returns the SF representor netdev name for a given uplink netdev and sfIndex.
@@ -335,7 +339,7 @@ func GetSfRepresentor(uplink string, sfNum int) (string, error) {
 			return device.Name(), nil
 		}
 	}
-	return "", fmt.Errorf("failed to find SF representor for uplink %s, sfNum %d", uplink, sfNum)
+	return "", fmt.Errorf("failed to get SF representor for uplink %s, sfNum %d: %w", uplink, sfNum, ErrRepresentorNotFound)
 }
 
 func getNetDevPhysPortName(netDev string) (string, error) {
@@ -486,7 +490,7 @@ func GetVfRepresentorDPU(pfID, vfIndex string) (string, error) {
 		return netdev, nil
 	}
 
-	return "", fmt.Errorf("vf representor for pfID: %s, vfIndex: %s not found", pfID, vfIndex)
+	return "", fmt.Errorf("failed to get VF representor for pfID: %s, vfIndex: %s: %w", pfID, vfIndex, ErrRepresentorNotFound)
 }
 
 // GetSfRepresentorDPU returns SF representor on DPU for a host SF identified by pfID and sfIndex
@@ -514,7 +518,7 @@ func GetSfRepresentorDPU(pfID, sfIndex string) (string, error) {
 		return netdev, nil
 	}
 
-	return "", fmt.Errorf("sf representor for pfID: %s, sfIndex: %s not found", pfID, sfIndex)
+	return "", fmt.Errorf("failed to get SF representor for pfID: %s, sfIndex: %s: %w", pfID, sfIndex, ErrRepresentorNotFound)
 }
 
 // GetPfRepresentorDPU returns PF representor on DPU for a host PF identified by its ID.
@@ -547,7 +551,7 @@ func GetPfRepresentorDPU(pfID string) (string, error) {
 		return netdev, nil
 	}
 
-	return "", fmt.Errorf("pf representor for pfID: %s not found", pfID)
+	return "", fmt.Errorf("failed to get PF representor for pfID: %s: %w", pfID, ErrRepresentorNotFound)
 }
 
 // GetRepresentorPortFlavour returns the representor port flavour

--- a/sriovnet_switchdev_test.go
+++ b/sriovnet_switchdev_test.go
@@ -268,6 +268,7 @@ func TestGetVfRepresentor(t *testing.T) {
 		vfIndex          int
 		expectedVFRep    string
 		shouldFail       bool
+		expectedErr      error
 	}{
 		{
 			name:             "VF representor found",
@@ -294,6 +295,7 @@ func TestGetVfRepresentor(t *testing.T) {
 			vfIndex:       5,
 			expectedVFRep: "",
 			shouldFail:    true,
+			expectedErr:   ErrRepresentorNotFound,
 		},
 		{
 			name:             "VF representor not found - no representors",
@@ -303,6 +305,7 @@ func TestGetVfRepresentor(t *testing.T) {
 			vfIndex:          0,
 			expectedVFRep:    "",
 			shouldFail:       true,
+			expectedErr:      ErrRepresentorNotFound,
 		},
 		{
 			name:             "VF representor not found - invalid phys_port_name",
@@ -315,6 +318,7 @@ func TestGetVfRepresentor(t *testing.T) {
 			vfIndex:       0,
 			expectedVFRep: "",
 			shouldFail:    true,
+			expectedErr:   ErrRepresentorNotFound,
 		},
 		{
 			name:             "VF representor not found - missing phys_port_name",
@@ -327,6 +331,7 @@ func TestGetVfRepresentor(t *testing.T) {
 			vfIndex:       0,
 			expectedVFRep: "",
 			shouldFail:    true,
+			expectedErr:   ErrRepresentorNotFound,
 		},
 		{
 			name:             "uplink is not switchdev",
@@ -376,6 +381,7 @@ func TestGetVfRepresentor(t *testing.T) {
 			vfIndex:       2,
 			expectedVFRep: "",
 			shouldFail:    true,
+			expectedErr:   ErrRepresentorNotFound,
 		},
 	}
 
@@ -393,6 +399,9 @@ func TestGetVfRepresentor(t *testing.T) {
 			vfRep, err := GetVfRepresentor(tcase.uplink.Name, tcase.vfIndex)
 			if tcase.shouldFail {
 				assert.Error(t, err)
+				if tcase.expectedErr != nil {
+					assert.ErrorIs(t, err, tcase.expectedErr)
+				}
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tcase.expectedVFRep, vfRep)
@@ -473,6 +482,7 @@ func TestGetUplinkRepresentorWithPhysPortName(t *testing.T) {
 		vfReps               []*repContext
 		expectedUplinkNetdev string
 		shouldFail           bool
+		expectedErr          error
 	}{
 		{
 			name:         "uplink representor exists",
@@ -506,6 +516,7 @@ func TestGetUplinkRepresentorWithPhysPortName(t *testing.T) {
 			},
 			expectedUplinkNetdev: "",
 			shouldFail:           true,
+			expectedErr:          ErrRepresentorNotFound,
 		},
 		{
 			name:         "uplink representor missing switch id",
@@ -518,6 +529,7 @@ func TestGetUplinkRepresentorWithPhysPortName(t *testing.T) {
 			},
 			expectedUplinkNetdev: "",
 			shouldFail:           true,
+			expectedErr:          ErrRepresentorNotFound,
 		},
 		{
 			name:                 "no representors",
@@ -527,6 +539,7 @@ func TestGetUplinkRepresentorWithPhysPortName(t *testing.T) {
 			vfReps:               []*repContext{},
 			expectedUplinkNetdev: "",
 			shouldFail:           true,
+			expectedErr:          ErrRepresentorNotFound,
 		},
 		{
 			name:                 "missing uplink",
@@ -560,6 +573,9 @@ func TestGetUplinkRepresentorWithPhysPortName(t *testing.T) {
 			uplinkNetdev, err := GetUplinkRepresentor(queryAddr)
 			if tcase.shouldFail {
 				assert.Error(t, err)
+				if tcase.expectedErr != nil {
+					assert.ErrorIs(t, err, tcase.expectedErr)
+				}
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tcase.expectedUplinkNetdev, uplinkNetdev)
@@ -592,7 +608,6 @@ func TestGetUplinkRepresentorErrorEmptySwID(t *testing.T) {
 	pfPciAddress := "0000:03:00.0"
 	vfPciAddress := "0000:03:00.4"
 	uplinkRep := &repContext{Name: "eth0", PhysPortName: "", PhysSwitchID: ""}
-	expectedError := fmt.Sprintf("uplink for %s not found", vfPciAddress)
 
 	// mock netlink calls, trigger failure to fallback to sysfs
 	nlOpsMock := netlinkopsMocks.NewMockNetlinkOps(t)
@@ -615,7 +630,7 @@ func TestGetUplinkRepresentorErrorEmptySwID(t *testing.T) {
 	uplinkNetdev, err := GetUplinkRepresentor(vfPciAddress)
 	assert.Error(t, err)
 	assert.Equal(t, "", uplinkNetdev)
-	assert.Equal(t, expectedError, err.Error())
+	assert.ErrorIs(t, err, ErrRepresentorNotFound)
 }
 
 func TestGetUplinkRepresentorDevlink(t *testing.T) {
@@ -722,6 +737,7 @@ func TestGetVfRepresentorDPU(t *testing.T) {
 		vfID          string
 		expectedVFRep string
 		shouldFail    bool
+		expectedErr   error
 	}{
 		{
 			name: "Host VFs only",
@@ -771,6 +787,7 @@ func TestGetVfRepresentorDPU(t *testing.T) {
 			vfID:          "5",
 			expectedVFRep: "",
 			shouldFail:    true,
+			expectedErr:   ErrRepresentorNotFound,
 		},
 		{
 			name:          "invalid pfID",
@@ -805,6 +822,9 @@ func TestGetVfRepresentorDPU(t *testing.T) {
 			vfRep, err := GetVfRepresentorDPU(tcase.pfID, tcase.vfID)
 			if tcase.shouldFail {
 				assert.Error(t, err)
+				if tcase.expectedErr != nil {
+					assert.ErrorIs(t, err, tcase.expectedErr)
+				}
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tcase.expectedVFRep, vfRep)
@@ -820,6 +840,7 @@ func TestGetPfRepresentorDPU(t *testing.T) {
 		pfID          string
 		expectedPfRep string
 		shouldFail    bool
+		expectedErr   error
 	}{
 		{
 			name: "PF representor with controller index",
@@ -861,6 +882,7 @@ func TestGetPfRepresentorDPU(t *testing.T) {
 			pfID:          "1",
 			expectedPfRep: "",
 			shouldFail:    true,
+			expectedErr:   ErrRepresentorNotFound,
 		},
 		{
 			name:          "invalid pfID",
@@ -885,6 +907,9 @@ func TestGetPfRepresentorDPU(t *testing.T) {
 			pfRep, err := GetPfRepresentorDPU(tcase.pfID)
 			if tcase.shouldFail {
 				assert.Error(t, err)
+				if tcase.expectedErr != nil {
+					assert.ErrorIs(t, err, tcase.expectedErr)
+				}
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tcase.expectedPfRep, pfRep)
@@ -905,6 +930,7 @@ func TestGetSfRepresentor(t *testing.T) {
 		sfIndex          int
 		expectedSFRep    string
 		shouldFail       bool
+		expectedErr      error
 	}{
 		{
 			name:             "Local SFs only",
@@ -948,6 +974,7 @@ func TestGetSfRepresentor(t *testing.T) {
 			sfIndex:       2,
 			expectedSFRep: "",
 			shouldFail:    true,
+			expectedErr:   ErrRepresentorNotFound,
 		},
 		{
 			name:             "SF rep no found no reps",
@@ -958,6 +985,7 @@ func TestGetSfRepresentor(t *testing.T) {
 			sfIndex:          2,
 			expectedSFRep:    "",
 			shouldFail:       true,
+			expectedErr:      ErrRepresentorNotFound,
 		},
 		{
 			name:             "SF rep no found only external reps",
@@ -972,6 +1000,7 @@ func TestGetSfRepresentor(t *testing.T) {
 			sfIndex:       2,
 			expectedSFRep: "",
 			shouldFail:    true,
+			expectedErr:   ErrRepresentorNotFound,
 		},
 		{
 			name:             "SF rep no found sf index not found",
@@ -985,6 +1014,7 @@ func TestGetSfRepresentor(t *testing.T) {
 			sfIndex:       3,
 			expectedSFRep: "",
 			shouldFail:    true,
+			expectedErr:   ErrRepresentorNotFound,
 		},
 		{
 			name:             "SF rep not found - no uplink",
@@ -1012,6 +1042,9 @@ func TestGetSfRepresentor(t *testing.T) {
 			sfRep, err := GetSfRepresentor(tcase.uplinkToCall, tcase.sfIndex)
 			if tcase.shouldFail {
 				assert.Error(t, err)
+				if tcase.expectedErr != nil {
+					assert.ErrorIs(t, err, tcase.expectedErr)
+				}
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tcase.expectedSFRep, sfRep)
@@ -1294,6 +1327,7 @@ func TestGetSfRepresentorDPU(t *testing.T) {
 		sfID          string
 		expectedSFRep string
 		shouldFail    bool
+		expectedErr   error
 	}{
 		{
 			name: "Host SFs only",
@@ -1331,6 +1365,7 @@ func TestGetSfRepresentorDPU(t *testing.T) {
 			sfID:          "2",
 			expectedSFRep: "",
 			shouldFail:    true,
+			expectedErr:   ErrRepresentorNotFound,
 		},
 		{
 			name: "SF representor not found",
@@ -1341,6 +1376,7 @@ func TestGetSfRepresentorDPU(t *testing.T) {
 			sfID:          "5",
 			expectedSFRep: "",
 			shouldFail:    true,
+			expectedErr:   ErrRepresentorNotFound,
 		},
 		{
 			name:          "invalid pfID",
@@ -1375,6 +1411,9 @@ func TestGetSfRepresentorDPU(t *testing.T) {
 			vfRep, err := GetSfRepresentorDPU(tcase.pfID, tcase.sfID)
 			if tcase.shouldFail {
 				assert.Error(t, err)
+				if tcase.expectedErr != nil {
+					assert.ErrorIs(t, err, tcase.expectedErr)
+				}
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tcase.expectedSFRep, vfRep)


### PR DESCRIPTION
wrap with dedicated ErrRepresentorNotFound error
when representor netdev was not found.

this will allow callers to distinguish between
"not found" type of errors and other errors.